### PR TITLE
Fix CsWin32 0.3 CI break and Windows 11 detection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup .Net SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
 
       - name: Build
         run: dotnet build -c Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .Net SDK
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -6,18 +6,22 @@ on:
     paths-ignore:
       - 'docs/**'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: master
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup .Net SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
 
       - name: Install XMLDoc2Markdown
         run: dotnet tool install -g Nefarius.Tools.XMLDoc2Markdown

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .Net SDK
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -9,14 +9,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup .Net SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
 
       - name: Modify README.md for NuGet
         run: |
@@ -29,6 +29,8 @@ jobs:
         run: dotnet pack -c Release
 
       - name: Publish To Nuget
-        run: dotnet nuget push bin/*.nupkg -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
+        run: |
+          dotnet nuget push bin/*.nupkg --skip-duplicate -k "$NUGET_AUTH_TOKEN" -s https://api.nuget.org/v3/index.json
+          dotnet nuget push bin/*.snupkg --skip-duplicate -k "$NUGET_AUTH_TOKEN" -s https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Benjamin Höglinger-Stelzer
+Copyright (c) 2022-2026 Benjamin Höglinger-Stelzer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # <img src="assets/NSS-128x128.png" align="left" />Nefarius.Utilities.WindowsVersion
 
 [![.NET](https://github.com/nefarius/Nefarius.Utilities.WindowsVersion/actions/workflows/build.yml/badge.svg)](https://github.com/nefarius/Nefarius.Utilities.WindowsVersion/actions/workflows/build.yml)
-![Requirements](https://img.shields.io/badge/Requires-.NET%20Standard%202.0-blue.svg)
+![Requirements](https://img.shields.io/badge/Requires-.NET%20Standard%202.0%20%7C%20.NET%2010-blue.svg)
 [![Nuget](https://img.shields.io/nuget/v/Nefarius.Utilities.WindowsVersion)](https://www.nuget.org/packages/Nefarius.Utilities.WindowsVersion/) [![Nuget](https://img.shields.io/nuget/dt/Nefarius.Utilities.WindowsVersion)](https://www.nuget.org/packages/Nefarius.Utilities.WindowsVersion/)
 
 Utility classes to get detailed Windows version and some extras like UEFI and BCD properties.
 
 ## Features
 
-- Get detailed information about most (all?) known Windows versions and editions out there
+- Get detailed information about most known Windows versions and editions out there
   - Service Pack (where it applies)
   - Edition like Home, Professional etc. (where it applies)
   - Server or client OS
-  - Release and Build numbers
+  - Distinguishes Windows 10 from Windows 11 (build 22000+) and names Server 2016 through 2025
+  - Release (`DisplayVersion` such as 24H2), build, and UBR revision numbers
   - Whether the OS installation is fresh or grandfathered (in-place upgraded from an older version)
 - Read and write Boot Configuration Data (BCD)
   - Currently only querying or setting test-signing is implemented
@@ -24,7 +25,7 @@ Utility classes to get detailed Windows version and some extras like UEFI and BC
 
 ## Documentation
 
-[Link to API docs](docs/index.md).
+[API documentation](https://github.com/nefarius/Nefarius.Utilities.WindowsVersion/blob/master/docs/index.md).
 
 ## Sources & 3rd party credits
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Utility classes to get detailed Windows version and some extras like UEFI and BC
   - Service Pack (where it applies)
   - Edition like Home, Professional etc. (where it applies)
   - Server or client OS
-  - Distinguishes Windows 10 from Windows 11 (build 22000+) and names Server 2016 through 2025
+  - Distinguishes Windows 10 from Windows 11 client systems (build 22000+) and names Server 2016 through 2025
   - Release (`DisplayVersion` such as 24H2), build, and UBR revision numbers
   - Whether the OS installation is fresh or grandfathered (in-place upgraded from an older version)
 - Read and write Boot Configuration Data (BCD)

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -1,7 +1,19 @@
-﻿// See https://aka.ms/new-console-template for more information
+﻿using Nefarius.Utilities.WindowsVersion.Util;
 
-using Nefarius.Utilities.WindowsVersion.Util;
-
-var t = CodeIntegrityHelper.IsTestSignEnabled;
-
-Console.WriteLine(OperatingSystem.IsWindowsVersionAtLeast(10));
+Console.WriteLine($"Name: {OsVersionInfo.Name}");
+Console.WriteLine($"Edition: {OsVersionInfo.Edition}");
+Console.WriteLine($"Version: {OsVersionInfo.VersionString}");
+Console.WriteLine($"DisplayVersion: {OsVersionInfo.DisplayVersion}");
+Console.WriteLine($"IsWindows10: {OsVersionInfo.IsWindows10}");
+Console.WriteLine($"IsWindows11: {OsVersionInfo.IsWindows11}");
+Console.WriteLine($"IsWindowsServer: {OsVersionInfo.IsWindowsServer}");
+Console.WriteLine($"IsUacDisabled: {OsVersionInfo.IsUacDisabled}");
+Console.WriteLine($"IsGrandfathered: {OsUpgradeDetection.IsGrandfathered}");
+Console.WriteLine($"IsArm64: {ArchitectureInfo.IsArm64}");
+Console.WriteLine($"ProcessorBits: {ArchitectureInfo.ProcessorBits}");
+Console.WriteLine($"OsBits: {ArchitectureInfo.OsBits}");
+Console.WriteLine($"ProgramBits: {ArchitectureInfo.ProgramBits}");
+Console.WriteLine($"IsRunningInUefiMode: {UefiHelper.IsRunningInUefiMode}");
+Console.WriteLine($"IsSecureBootEnabled: {UefiHelper.IsSecureBootEnabled}");
+Console.WriteLine($"IsTestSignEnabled: {CodeIntegrityHelper.IsTestSignEnabled}");
+Console.WriteLine($"WhqlDeveloperTestMode: {CodeIntegrityPolicyHelper.WhqlDeveloperTestMode}");

--- a/app/app.csproj
+++ b/app/app.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/app/app.csproj
+++ b/app/app.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <EnableWindowsTargeting>true</EnableWindowsTargeting>
     </PropertyGroup>
 
     <ItemGroup>

--- a/docs/nefarius.utilities.windowsversion.util.osversioninfo.md
+++ b/docs/nefarius.utilities.windowsversion.util.osversioninfo.md
@@ -25,6 +25,18 @@ public static Nullable<Int32> BuildVersion { get; }
 
 [Nullable](https://learn.microsoft.com/dotnet/api/system.nullable-1)<[Int32](https://learn.microsoft.com/dotnet/api/system.int32)><br>
 
+### <a id="properties-displayversion"/>**DisplayVersion**
+
+Feature-update label such as 22H2 or 24H2, when the OS reports one.
+
+```csharp
+public static string DisplayVersion { get; }
+```
+
+#### Property Value
+
+[String](https://learn.microsoft.com/dotnet/api/system.string)<br>
+
 ### <a id="properties-edition"/>**Edition**
 
 Gets the edition of the operating system running on this computer.
@@ -64,6 +76,18 @@ public static bool IsWindows10 { get; }
 **Remarks:**
 
 This also includes Windows 11 due to the stupidity and inconsistency of Microsoft's versioning strategy.
+
+### <a id="properties-iswindows11"/>**IsWindows11**
+
+True if the current system is a Windows 11 client (build 22000 or later).
+
+```csharp
+public static bool IsWindows11 { get; }
+```
+
+#### Property Value
+
+[Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)<br>
 
 ### <a id="properties-iswindowsserver"/>**IsWindowsServer**
 

--- a/docs/nefarius.utilities.windowsversion.util.processorarchitecture.md
+++ b/docs/nefarius.utilities.windowsversion.util.processorarchitecture.md
@@ -19,3 +19,4 @@ Implements [IComparable](https://learn.microsoft.com/dotnet/api/system.icomparab
 | Bit32 | 1 | 32-Bits (a.k.a x86). |
 | Bit64 | 2 | 64-Bits (a.k.a. x86_64). |
 | Itanium64 | 3 | IA-64 (Intel Itanium architecture). |
+| Arm64 | 4 | ARM64 (AArch64). |

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,9 @@
   <PropertyGroup>
     <!-- Copyright information -->
     <Authors>Benjamin Höglinger-Stelzer</Authors>
-    <Copyright>Copyright © Benjamin Höglinger-Stelzer 2022-2025</Copyright>
+    <Copyright>Copyright © Benjamin Höglinger-Stelzer 2022-2026</Copyright>
+    <Description>Utility classes to get detailed Windows version information and extras like UEFI, BCD, and code-integrity properties.</Description>
+    <PackageTags>windows;version;os;uefi;bcd;secureboot</PackageTags>
 
     <!-- Package Icon -->
     <PackageIcon>NSS-128x128.png</PackageIcon>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,6 +15,7 @@
     <!-- Common solution settings -->
     <OutputPath>$(SolutionDir)bin\</OutputPath>
     <LangVersion>latest</LangVersion>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <!-- Docs and symbols generation -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Exceptions/BcdAlterAllowPrereleaseSignaturesFailedException.cs
+++ b/src/Exceptions/BcdAlterAllowPrereleaseSignaturesFailedException.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 
@@ -24,8 +25,10 @@ public class BcdAlterAllowPrereleaseSignaturesFailedException : Exception
     {
     }
 
+#pragma warning disable SYSLIB0051
     internal BcdAlterAllowPrereleaseSignaturesFailedException(SerializationInfo info, StreamingContext context) :
         base(info, context)
     {
     }
+#pragma warning restore SYSLIB0051
 }

--- a/src/NativeMethods.txt
+++ b/src/NativeMethods.txt
@@ -3,6 +3,9 @@ GetModuleHandle
 WIN32_ERROR
 LoadLibrary
 GetNativeSystemInfo
+IsWow64Process
 IsWow64Process2
 GetFirmwareEnvironmentVariable
 IsOS
+NtQuerySystemInformation
+SYSTEM_CODEINTEGRITY_INFORMATION

--- a/src/Nefarius.Utilities.WindowsVersion.csproj
+++ b/src/Nefarius.Utilities.WindowsVersion.csproj
@@ -1,14 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net10.0-windows10.0.17763.0</TargetFrameworks>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.0.0</Version>
-        <PackageIcon>NSS-128x128.png</PackageIcon>
-        <PackageIconUrl />
         <RepositoryUrl>https://github.com/nefarius/Nefarius.Utilities.WindowsVersion</RepositoryUrl>
         <PackageProjectUrl>https://github.com/nefarius/Nefarius.Utilities.WindowsVersion</PackageProjectUrl>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -17,7 +15,6 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.321">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -27,7 +24,12 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
         <PackageReference Include="System.Memory" Version="4.6.3" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     </ItemGroup>
 
 </Project>

--- a/src/Util/ArchitectureInfo.cs
+++ b/src/Util/ArchitectureInfo.cs
@@ -9,8 +9,6 @@ using Windows.Win32.System.SystemInformation;
 
 using JetBrains.Annotations;
 
-using Microsoft.Win32.SafeHandles;
-
 namespace Nefarius.Utilities.WindowsVersion.Util;
 
 /// <summary>
@@ -82,8 +80,8 @@ public static class ArchitectureInfo
         {
             try
             {
-                SafeProcessHandle handle = Process.GetCurrentProcess().SafeHandle;
-                if (!PInvoke.IsWow64Process2(handle, out _, out IMAGE_FILE_MACHINE nativeMachine))
+                using Process process = Process.GetCurrentProcess();
+                if (!PInvoke.IsWow64Process2(process.SafeHandle, out _, out IMAGE_FILE_MACHINE nativeMachine))
                 {
                     return false;
                 }
@@ -174,7 +172,7 @@ public static class ArchitectureInfo
 
     private static bool Is32BitProcessOn64BitProcessor()
     {
-        SafeProcessHandle handle = Process.GetCurrentProcess().SafeHandle;
-        return PInvoke.IsWow64Process(handle, out BOOL isWow64) && isWow64;
+        using Process process = Process.GetCurrentProcess();
+        return PInvoke.IsWow64Process(process.SafeHandle, out BOOL isWow64) && isWow64;
     }
 }

--- a/src/Util/ArchitectureInfo.cs
+++ b/src/Util/ArchitectureInfo.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 
 using Windows.Win32;
+using Windows.Win32.Foundation;
 using Windows.Win32.System.SystemInformation;
 
 using JetBrains.Annotations;
@@ -56,7 +57,12 @@ public enum ProcessorArchitecture
     /// <summary>
     ///     IA-64 (Intel Itanium architecture).
     /// </summary>
-    Itanium64 = 3
+    Itanium64 = 3,
+
+    /// <summary>
+    ///     ARM64 (AArch64).
+    /// </summary>
+    Arm64 = 4
 }
 
 /// <summary>
@@ -70,15 +76,28 @@ public static class ArchitectureInfo
     /// <summary>
     ///     Gets whether the current process is running on ARM64.
     /// </summary>
-    public static unsafe bool IsArm64
+    public static bool IsArm64
     {
         get
         {
-            SafeProcessHandle handle = Process.GetCurrentProcess().SafeHandle;
-            IMAGE_FILE_MACHINE nativeMachine;
-            PInvoke.IsWow64Process2(handle, out _, &nativeMachine);
+            try
+            {
+                SafeProcessHandle handle = Process.GetCurrentProcess().SafeHandle;
+                if (!PInvoke.IsWow64Process2(handle, out _, out IMAGE_FILE_MACHINE nativeMachine))
+                {
+                    return false;
+                }
 
-            return nativeMachine == IMAGE_FILE_MACHINE.IMAGE_FILE_MACHINE_ARM64;
+                return nativeMachine == IMAGE_FILE_MACHINE.IMAGE_FILE_MACHINE_ARM64;
+            }
+            catch (EntryPointNotFoundException)
+            {
+                return false;
+            }
+            catch (DllNotFoundException)
+            {
+                return false;
+            }
         }
     }
 
@@ -139,6 +158,8 @@ public static class ArchitectureInfo
                         ProcessorArchitecture.Itanium64,
                     PROCESSOR_ARCHITECTURE.PROCESSOR_ARCHITECTURE_INTEL =>
                         ProcessorArchitecture.Bit32,
+                    PROCESSOR_ARCHITECTURE.PROCESSOR_ARCHITECTURE_ARM64 =>
+                        ProcessorArchitecture.Arm64,
                     _ => ProcessorArchitecture.Unknown
                 };
             }
@@ -151,39 +172,9 @@ public static class ArchitectureInfo
         }
     }
 
-    private static IsWow64ProcessDelegate GetIsWow64ProcessDelegate()
-    {
-        FreeLibrarySafeHandle handle = PInvoke.LoadLibrary("kernel32");
-
-        if (handle.IsInvalid)
-        {
-            return null;
-        }
-
-        IntPtr fnPtr = PInvoke.GetProcAddress(handle, "IsWow64Process");
-
-        if (fnPtr != IntPtr.Zero)
-        {
-            return (IsWow64ProcessDelegate)Marshal.GetDelegateForFunctionPointer(fnPtr,
-                typeof(IsWow64ProcessDelegate));
-        }
-
-        return null;
-    }
-
     private static bool Is32BitProcessOn64BitProcessor()
     {
-        IsWow64ProcessDelegate fnDelegate = GetIsWow64ProcessDelegate();
-
-        if (fnDelegate == null)
-        {
-            return false;
-        }
-
-        bool retVal = fnDelegate.Invoke(Process.GetCurrentProcess().Handle, out bool isWow64);
-
-        return retVal && isWow64;
+        SafeProcessHandle handle = Process.GetCurrentProcess().SafeHandle;
+        return PInvoke.IsWow64Process(handle, out BOOL isWow64) && isWow64;
     }
-
-    private delegate bool IsWow64ProcessDelegate([In] IntPtr handle, [Out] out bool isWow64Process);
 }

--- a/src/Util/BcdHelper.cs
+++ b/src/Util/BcdHelper.cs
@@ -35,10 +35,10 @@ public static class BcdHelper
                 new ManagementPath(
                     "root\\WMI:BcdObject.Id=\"{fa926493-6f1c-4193-a414-58f0b2456d1e}\",StoreFilePath=\"\""),
                 null);
-            ManagementBaseObject inParams = bootMgrObj.GetMethodParameters("GetElement");
+            using ManagementBaseObject inParams = bootMgrObj.GetMethodParameters("GetElement");
 
             inParams["Type"] = BcdLibraryBoolean_AllowPrereleaseSignatures;
-            ManagementBaseObject? outParams = bootMgrObj.InvokeMethod("GetElement", inParams, null);
+            using ManagementBaseObject? outParams = bootMgrObj.InvokeMethod("GetElement", inParams, null);
             ManagementBaseObject? outObj = (ManagementBaseObject?)outParams?.Properties["Element"].Value;
 
             bool allowPrereleaseSignatures = outObj != null && (bool)outObj.GetPropertyValue("Boolean");
@@ -57,11 +57,11 @@ public static class BcdHelper
                 new ManagementPath(
                     "root\\WMI:BcdObject.Id=\"{fa926493-6f1c-4193-a414-58f0b2456d1e}\",StoreFilePath=\"\""),
                 null);
-            ManagementBaseObject inParams = bootMgrObj.GetMethodParameters("SetBooleanElement");
+            using ManagementBaseObject inParams = bootMgrObj.GetMethodParameters("SetBooleanElement");
 
             inParams["Type"] = BcdLibraryBoolean_AllowPrereleaseSignatures;
             inParams["Boolean"] = value;
-            ManagementBaseObject? outParams = bootMgrObj.InvokeMethod("SetBooleanElement", inParams, null);
+            using ManagementBaseObject? outParams = bootMgrObj.InvokeMethod("SetBooleanElement", inParams, null);
             object? ret = outParams?.Properties["ReturnValue"].Value;
             bool returnValue = ret != null && (bool)ret;
 

--- a/src/Util/CodeIntegrityHelper.cs
+++ b/src/Util/CodeIntegrityHelper.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 
-using Windows.Win32;
+using Windows.Wdk.System.SystemInformation;
 using Windows.Win32.Foundation;
+using Windows.Win32.System.WindowsProgramming;
 
 namespace Nefarius.Utilities.WindowsVersion.Util;
 
@@ -18,68 +19,28 @@ public static class CodeIntegrityHelper
     /// <summary>
     ///     Determines if the system is currently in TESTSIGNING mode.
     /// </summary>
-    public static bool IsTestSignEnabled
+    public static unsafe bool IsTestSignEnabled
     {
         get
         {
-            IntPtr pIntegrity = Marshal.AllocHGlobal(Marshal.SizeOf<SYSTEM_CODEINTEGRITY_INFORMATION>());
-
-            try
+            SYSTEM_CODEINTEGRITY_INFORMATION integrity = new()
             {
-                using FreeLibrarySafeHandle ntDll = PInvoke.GetModuleHandle("ntdll.dll");
-                FARPROC ptr = PInvoke.GetProcAddress(ntDll, "NtQuerySystemInformation");
+                Length = (uint)sizeof(SYSTEM_CODEINTEGRITY_INFORMATION)
+            };
 
-                NtQuerySystemInformation ntQuerySystemInformation =
-                    Marshal.GetDelegateForFunctionPointer<NtQuerySystemInformation>(ptr);
+            uint returnLength = 0;
+            NTSTATUS status = Windows.Wdk.PInvoke.NtQuerySystemInformation(
+                SYSTEM_INFORMATION_CLASS.SystemCodeIntegrityInformation,
+                &integrity,
+                integrity.Length,
+                ref returnLength);
 
-                SYSTEM_CODEINTEGRITY_INFORMATION integrity;
-                integrity.Length = (uint)Marshal.SizeOf<SYSTEM_CODEINTEGRITY_INFORMATION>();
-                integrity.CodeIntegrityOptions = 0;
-
-                Marshal.StructureToPtr(integrity, pIntegrity, false);
-
-                // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/codeintegrity.htm
-                int status = ntQuerySystemInformation(
-                    103, // SystemCodeIntegrityInformation (0x67)
-                    pIntegrity,
-                    integrity.Length,
-                    out _
-                );
-
-                int error = Marshal.GetLastWin32Error();
-
-                if (status != (int)WIN32_ERROR.ERROR_SUCCESS)
-                {
-                    throw new Win32Exception(error, "NtQuerySystemInformation failed");
-                }
-
-                integrity = Marshal.PtrToStructure<SYSTEM_CODEINTEGRITY_INFORMATION>(pIntegrity);
-
-                return (integrity.CodeIntegrityOptions & /* CODEINTEGRITY_OPTION_TESTSIGN */ 0x02) != 0;
-            }
-            finally
+            if ((int)status != 0)
             {
-                Marshal.FreeHGlobal(pIntegrity);
+                throw new Win32Exception((int)status, "NtQuerySystemInformation failed");
             }
+
+            return (integrity.CodeIntegrityOptions & /* CODEINTEGRITY_OPTION_TESTSIGN */ 0x02) != 0;
         }
     }
-
-    #region Native
-
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    private delegate int NtQuerySystemInformation(
-        uint systemInformationClass,
-        IntPtr systemInformation,
-        uint systemInformationLength,
-        out uint returnLength);
-
-    [StructLayout(LayoutKind.Sequential)]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    private struct SYSTEM_CODEINTEGRITY_INFORMATION
-    {
-        public uint Length;
-        public uint CodeIntegrityOptions;
-    }
-
-    #endregion
 }

--- a/src/Util/CodeIntegrityHelper.cs
+++ b/src/Util/CodeIntegrityHelper.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 using System;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 
 using Windows.Wdk.System.SystemInformation;
@@ -35,12 +34,21 @@ public static class CodeIntegrityHelper
                 integrity.Length,
                 ref returnLength);
 
-            if ((int)status != 0)
+            if ((int)status < 0)
             {
-                throw new Win32Exception((int)status, "NtQuerySystemInformation failed");
+                throw new NtStatusException(status);
             }
 
             return (integrity.CodeIntegrityOptions & /* CODEINTEGRITY_OPTION_TESTSIGN */ 0x02) != 0;
+        }
+    }
+
+    private sealed class NtStatusException : Exception
+    {
+        internal NtStatusException(NTSTATUS status)
+            : base($"NtQuerySystemInformation failed with NTSTATUS {status}")
+        {
+            HResult = status;
         }
     }
 }

--- a/src/Util/CodeIntegrityPolicyHelper.cs
+++ b/src/Util/CodeIntegrityPolicyHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 using JetBrains.Annotations;

--- a/src/Util/OSVersionInfo.Native.cs
+++ b/src/Util/OSVersionInfo.Native.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
@@ -13,7 +14,7 @@ public static partial class OsVersionInfo
 {
     #region OSVERSIONINFOEX
 
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     private struct OSVERSIONINFOEX
     {
         public int dwOSVersionInfoSize;
@@ -50,7 +51,7 @@ public static partial class OsVersionInfo
 
     #region VERSION
 
-    [DllImport("kernel32.dll")]
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
     private static extern bool GetVersionEx(ref OSVERSIONINFOEX osVersionInfo);
 
     #endregion VERSION
@@ -141,6 +142,20 @@ public static partial class OsVersionInfo
     private const int PRODUCT_ENTERPRISE_E = 0x00000046;
 
     private const int PRODUCT_ULTIMATE_E = 0x00000047;
+    private const int PRODUCT_CORE_N = 0x00000062;
+    private const int PRODUCT_CORE_COUNTRYSPECIFIC = 0x00000063;
+    private const int PRODUCT_CORE_SINGLELANGUAGE = 0x00000064;
+    private const int PRODUCT_CORE = 0x00000065;
+    private const int PRODUCT_EDUCATION = 0x00000079;
+    private const int PRODUCT_EDUCATION_N = 0x0000007A;
+    private const int PRODUCT_ENTERPRISE_S = 0x0000007D;
+    private const int PRODUCT_ENTERPRISE_S_N = 0x0000007E;
+    private const int PRODUCT_PRO_WORKSTATION = 0x000000A1;
+    private const int PRODUCT_PRO_WORKSTATION_N = 0x000000A2;
+    private const int PRODUCT_CLOUD = 0x000000B2;
+    private const int PRODUCT_CLOUDN = 0x000000B3;
+    private const int PRODUCT_IOTENTERPRISE = 0x000000BC;
+    private const int PRODUCT_IOTENTERPRISES = 0x000000BF;
     //private const int PRODUCT_UNLICENSED = 0xABCDABCD;
 
     #endregion PRODUCT

--- a/src/Util/OSVersionInfo.Server.cs
+++ b/src/Util/OSVersionInfo.Server.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#nullable enable
+using System.Diagnostics.CodeAnalysis;
 
 using Windows.Win32;
 using Windows.Win32.UI.Shell;

--- a/src/Util/OSVersionInfo.cs
+++ b/src/Util/OSVersionInfo.cs
@@ -1,9 +1,7 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.InteropServices;
 
 using Microsoft.Win32;
@@ -17,7 +15,7 @@ using Microsoft.Win32;
 //Thakts to Brisingr Aerowing for help with the Windows 10 adaptation
 // Maintained and extended by Benjamin Höglinger-Stelzer 2018-2022
 
-// Modified and extended by Benjamin "Nefarius" Höglinger-Stelzer 2022-2025
+// Modified and extended by Benjamin "Nefarius" Höglinger-Stelzer 2022-2026
 
 namespace Nefarius.Utilities.WindowsVersion.Util;
 
@@ -29,22 +27,40 @@ namespace Nefarius.Utilities.WindowsVersion.Util;
 [SuppressMessage("ReSharper", "UnusedType.Global")]
 public static partial class OsVersionInfo
 {
+    private const string NtCurrentVersionKey = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion";
+    private const int Windows11MinBuild = 22000;
+    private const int WindowsServer2016MinBuild = 14393;
+    private const int WindowsServer2019MinBuild = 17763;
+    private const int WindowsServer2022MinBuild = 20348;
+    private const int WindowsServer2025MinBuild = 26100;
+
+    private static object? GetNtCurrentVersionValue(string name)
+    {
+        return Registry.GetValue(NtCurrentVersionKey, name, null);
+    }
+
+    private static string? GetNtCurrentVersionString(string name)
+    {
+        return GetNtCurrentVersionValue(name) as string;
+    }
+
+    private static int? GetNtCurrentVersionDword(string name)
+    {
+        return GetNtCurrentVersionValue(name) switch
+        {
+            int value => value,
+            _ => null
+        };
+    }
+
     /// <summary>
-    ///     https://en.wikipedia.org/wiki/Windows_10_version_history#Channels
+    ///     Feature-update label such as 22H2 or 24H2, when the OS reports one.
     /// </summary>
-    private static readonly List<string> Windows10ReleaseIds =
-    [
-        "1507", // <-- 1st public release of Windows 10 codenamed "Threshold 1"
-        "1607",
-        "1703",
-        "1709",
-        "1803",
-        "1809",
-        "1903",
-        "1909",
-        "2004",
-        "2009" // <-- last time this value was actually updated by Microsoft
-    ];
+    public static string? DisplayVersion => GetNtCurrentVersionString("DisplayVersion");
+
+    private static string? ReleaseId => GetNtCurrentVersionString("ReleaseId");
+
+    private static string? EditionId => GetNtCurrentVersionString("EditionID");
 
     #region SERVICE PACK
 
@@ -76,17 +92,14 @@ public static partial class OsVersionInfo
     ///     True if the current system is Windows 10 or newer, false otherwise.
     /// </summary>
     /// <remarks>This also includes Windows 11 due to the stupidity and inconsistency of Microsoft's versioning strategy.</remarks>
-    public static bool IsWindows10
-    {
-        get
-        {
-            string? releaseId = (string?)Registry.GetValue(
-                @"HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion",
-                "ReleaseId", null);
+    public static bool IsWindows10 =>
+        GetNtCurrentVersionDword("CurrentMajorVersionNumber") >= 10 ||
+        !string.IsNullOrEmpty(ReleaseId);
 
-            return !string.IsNullOrEmpty(releaseId) && Windows10ReleaseIds.Any(id => id.Contains(releaseId));
-        }
-    }
+    /// <summary>
+    ///     True if the current system is a Windows 11 client (build 22000 or later).
+    /// </summary>
+    public static bool IsWindows11 => !IsWindowsServer && (BuildVersion ?? 0) >= Windows11MinBuild;
 
     #endregion
 
@@ -101,7 +114,6 @@ public static partial class OsVersionInfo
         {
             string edition = string.Empty;
 
-            OperatingSystem osVersion = Environment.OSVersion;
             OSVERSIONINFOEX osVersionInfo = new() { dwOSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
 
             if (!GetVersionEx(ref osVersionInfo))
@@ -109,8 +121,8 @@ public static partial class OsVersionInfo
                 return edition;
             }
 
-            int majorVersion = osVersion.Version.Major;
-            int minorVersion = osVersion.Version.Minor;
+            int majorVersion = MajorVersion;
+            int minorVersion = MinorVersion;
             byte productType = osVersionInfo.wProductType;
             short suiteMask = osVersionInfo.wSuiteMask;
 
@@ -200,7 +212,7 @@ public static partial class OsVersionInfo
 
                         break;
                     }
-                case 6:
+                case >= 6:
                     {
                         if (GetProductInfo(majorVersion, minorVersion,
                                 osVersionInfo.wServicePackMajor, osVersionInfo.wServicePackMinor,
@@ -286,8 +298,27 @@ public static partial class OsVersionInfo
                                 PRODUCT_ULTIMATE_E => "Ultimate E",
                                 PRODUCT_WEB_SERVER => "Web Server",
                                 PRODUCT_WEB_SERVER_CORE => "Web Server (core installation)",
+                                PRODUCT_CORE => "Home",
+                                PRODUCT_CORE_N => "Home N",
+                                PRODUCT_CORE_COUNTRYSPECIFIC => "Home China",
+                                PRODUCT_CORE_SINGLELANGUAGE => "Home Single Language",
+                                PRODUCT_EDUCATION => "Education",
+                                PRODUCT_EDUCATION_N => "Education N",
+                                PRODUCT_ENTERPRISE_S => "Enterprise LTSC",
+                                PRODUCT_ENTERPRISE_S_N => "Enterprise N LTSC",
+                                PRODUCT_PRO_WORKSTATION => "Pro for Workstations",
+                                PRODUCT_PRO_WORKSTATION_N => "Pro for Workstations N",
+                                PRODUCT_CLOUD => "S",
+                                PRODUCT_CLOUDN => "S N",
+                                PRODUCT_IOTENTERPRISE => "IoT Enterprise",
+                                PRODUCT_IOTENTERPRISES => "IoT Enterprise LTSC",
                                 _ => edition
                             };
+                        }
+
+                        if (string.IsNullOrEmpty(edition))
+                        {
+                            edition = EditionId ?? string.Empty;
                         }
 
                         break;
@@ -312,16 +343,12 @@ public static partial class OsVersionInfo
             using RegistryKey? key = Registry.LocalMachine.OpenSubKey(
                 @"SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System");
 
-            return !int.TryParse(key?.GetValue("ConsentPromptBehaviorAdmin")?.ToString(), out int value) ||
-                   value != 5;
+            return int.TryParse(key?.GetValue("EnableLUA")?.ToString(), out int enableLua) &&
+                   enableLua == 0;
         }
     }
 
     #region NAME
-
-    private static string? ReleaseId => (string?)Registry.GetValue(
-        @"HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion",
-        "ReleaseId", null);
 
     /// <summary>
     ///     Gets the name of the operating system running on this computer.
@@ -340,34 +367,8 @@ public static partial class OsVersionInfo
                 return name;
             }
 
-            int majorVersion = osVersion.Version.Major;
-            int minorVersion = osVersion.Version.Minor;
-
-            // TODO: deprecate this. Use a proper manifest. Always.
-            if (majorVersion == 6 && minorVersion == 2)
-            {
-                //The registry read workaround is by Scott Vickery. Thanks a lot for the help!
-
-                //http://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx
-
-                // For applications that have been manifested for Windows 8.1 & Windows 10. Applications not manifested for 8.1 or 10 will return the Windows 8 OS version value (6.2). 
-                // By reading the registry, we'll get the exact version - meaning we can even compare against  Win 8 and Win 8.1.
-                string? exactVersion =
-                    Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion",
-                        "CurrentVersion", null) as string;
-                if (!string.IsNullOrEmpty(exactVersion))
-                {
-                    string[] splitResult = exactVersion!.Split('.');
-                    majorVersion = Convert.ToInt32(splitResult[0]);
-                    minorVersion = Convert.ToInt32(splitResult[1]);
-                }
-
-                if (IsWindows10)
-                {
-                    majorVersion = 10;
-                    minorVersion = 0;
-                }
-            }
+            int majorVersion = MajorVersion;
+            int minorVersion = MinorVersion;
 
             switch (osVersion.Platform)
             {
@@ -455,7 +456,7 @@ public static partial class OsVersionInfo
 
                                 break;
                             case 10:
-                                name = ParseWindows10Version(minorVersion, productType, ReleaseId ?? "0");
+                                name = ParseWindows10Version(minorVersion, productType);
 
                                 break;
                         }
@@ -518,28 +519,45 @@ public static partial class OsVersionInfo
         return string.Empty;
     }
 
-    private static string ParseWindows10Version(int minorVersion, byte productType, string releaseId)
+    private static string ParseWindows10Version(int minorVersion, byte productType)
     {
-        switch (minorVersion)
+        if (minorVersion != 0)
         {
-            case 0:
-                switch (productType)
-                {
-                    case 1:
-                        return $"Windows 10 ({ReleaseId})";
-                    case 3:
-                        switch (releaseId)
-                        {
-                            case "1607":
-                                return "Windows Server 2016";
-                            case "1809":
-                                return "Windows Server 2019";
-                        }
+            return string.Empty;
+        }
 
-                        break;
+        string label = DisplayVersion ?? ReleaseId ?? BuildVersion?.ToString() ?? "0";
+        int build = BuildVersion ?? 0;
+
+        switch (productType)
+        {
+            case VER_NT_WORKSTATION:
+                return build >= Windows11MinBuild
+                    ? $"Windows 11 ({label})"
+                    : $"Windows 10 ({label})";
+            case VER_NT_DOMAIN_CONTROLLER:
+            case VER_NT_SERVER:
+                if (build >= WindowsServer2025MinBuild)
+                {
+                    return "Windows Server 2025";
                 }
 
-                break;
+                if (build >= WindowsServer2022MinBuild)
+                {
+                    return "Windows Server 2022";
+                }
+
+                if (build >= WindowsServer2019MinBuild)
+                {
+                    return "Windows Server 2019";
+                }
+
+                if (build >= WindowsServer2016MinBuild)
+                {
+                    return "Windows Server 2016";
+                }
+
+                return $"Windows Server ({label})";
         }
 
         return string.Empty;
@@ -558,11 +576,7 @@ public static partial class OsVersionInfo
     {
         get
         {
-            string? value = (string?)Registry.GetValue(
-                @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion",
-                "CurrentBuildNumber",
-                null
-            );
+            string? value = GetNtCurrentVersionString("CurrentBuildNumber");
 
             if (string.IsNullOrEmpty(value))
             {
@@ -611,13 +625,13 @@ public static partial class OsVersionInfo
     {
         get
         {
-            if (IsWindows10)
+            int? major = GetNtCurrentVersionDword("CurrentMajorVersionNumber");
+            if (major.HasValue)
             {
-                return 10;
+                return major.Value;
             }
 
-            string? exactVersion = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion",
-                "CurrentVersion", null) as string;
+            string? exactVersion = GetNtCurrentVersionString("CurrentVersion");
 
             if (string.IsNullOrEmpty(exactVersion))
             {
@@ -640,13 +654,13 @@ public static partial class OsVersionInfo
     {
         get
         {
-            if (IsWindows10)
+            int? minor = GetNtCurrentVersionDword("CurrentMinorVersionNumber");
+            if (minor.HasValue)
             {
-                return 0;
+                return minor.Value;
             }
 
-            string? exactVersion = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion",
-                "CurrentVersion", null) as string;
+            string? exactVersion = GetNtCurrentVersionString("CurrentVersion");
 
             if (string.IsNullOrEmpty(exactVersion))
             {
@@ -665,7 +679,9 @@ public static partial class OsVersionInfo
     /// <summary>
     ///     Gets the revision version number of the operating system running on this computer.
     /// </summary>
-    public static int RevisionVersion => IsWindows10 ? 0 : Environment.OSVersion.Version.Revision;
+    public static int RevisionVersion =>
+        GetNtCurrentVersionDword("UBR") ??
+        (IsWindows10 ? 0 : Environment.OSVersion.Version.Revision);
 
     #endregion REVISION
 

--- a/src/Util/OsUpgradeDetection.cs
+++ b/src/Util/OsUpgradeDetection.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -21,33 +22,25 @@ public static class OsUpgradeDetection
     {
         get
         {
-            using RegistryKey setupKey = Registry.LocalMachine.OpenSubKey(@"SYSTEM\Setup");
-            using RegistryKey upgradeKey = setupKey?.OpenSubKey("Upgrade");
-            // if this key isn't there, don't look any further
-            if (upgradeKey == null)
+            using RegistryKey? setupKey = Registry.LocalMachine.OpenSubKey(@"SYSTEM\Setup");
+            if (setupKey is null)
             {
                 return false;
             }
 
-            // only look at "Source OS (...)" sub-keys
+            using RegistryKey? upgradeKey = setupKey.OpenSubKey("Upgrade");
+            if (upgradeKey is null)
+            {
+                return false;
+            }
+
             foreach (string sosKeyName in setupKey.GetSubKeyNames().Where(v =>
                          v.StartsWith("Source OS", StringComparison.InvariantCultureIgnoreCase)))
             {
-                using RegistryKey sosKey = setupKey.OpenSubKey(sosKeyName);
-                string productName = sosKey?.GetValue("ProductName") as string;
+                using RegistryKey? sosKey = setupKey.OpenSubKey(sosKeyName);
+                string? productName = sosKey?.GetValue("ProductName") as string;
 
-                if (string.IsNullOrEmpty(productName))
-                {
-                    continue;
-                }
-
-                // TODO: untested but should work
-                if (productName.StartsWith("Windows 7", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    return true;
-                }
-
-                if (productName.StartsWith("Windows 8", StringComparison.InvariantCultureIgnoreCase))
+                if (!string.IsNullOrEmpty(productName))
                 {
                     return true;
                 }

--- a/src/Util/UEFIHelper.cs
+++ b/src/Util/UEFIHelper.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#nullable enable
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 using Windows.Win32;
@@ -40,18 +42,16 @@ public static class UefiHelper
     ///     Source:
     ///     https://theroadtodelphi.com/2013/02/19/how-distinguish-when-windows-was-installed-in-legacy-bios-or-uefi-mode-using-delphi/
     /// </remarks>
-    public static unsafe bool IsRunningInUefiMode
+    public static bool IsRunningInUefiMode
     {
         get
         {
-            // The arguments submitted are dummy values; GetLastError will
-            // report ERROR_INVALID_FUNCTION on Legacy BIOS systems.
+            // Dummy name/GUID + empty buffer; GetLastError reports
+            // ERROR_INVALID_FUNCTION on Legacy BIOS systems.
             PInvoke.GetFirmwareEnvironmentVariable(
                 string.Empty,
                 "{00000000-0000-0000-0000-000000000000}",
-                null,
-                0
-            );
+                Span<byte>.Empty);
 
             return Marshal.GetLastWin32Error() != (int)WIN32_ERROR.ERROR_INVALID_FUNCTION;
         }


### PR DESCRIPTION
## Summary
- Bind CsWin32 0.3.321 friendly overloads so Release builds succeed again, and multi-target `net10.0-windows` with SDK 10 CI.
- Correct Windows 11 / Server naming, edition, UAC, UBR, and grandfathered-upgrade detection; add `IsWindows11` and `DisplayVersion`.

## Test plan
- [ ] Confirm `.NET` and `Generate API Documentation` workflows pass
- [ ] `dotnet build -c Release` locally for `netstandard2.0` and `net10.0-windows10.0.17763.0`
- [ ] On a Windows 11 machine, `OsVersionInfo.Name` is `Windows 11 (...)` and `IsWindows11` is true
- [ ] On Windows 10, `IsWindows10` remains true and `IsWindows11` is false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows 11 and display-version detection.
  * Improved Windows edition and Server 2016–2025 identification.
  * Added ARM64 architecture detection.
  * Enhanced reporting for UEFI status, code integrity, upgrades, and system architecture.
  * Added .NET 10 support alongside .NET Standard 2.0.

* **Documentation**
  * Expanded Windows version documentation and updated API links.
  * Documented new Windows version properties and ARM64 support.

* **Maintenance**
  * Updated package metadata, licensing information, and automated build and publishing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->