### PR TITLE
Publish to NuGet with Trusted Publishing instead of a stored API key.

### DIFF
--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:
@@ -29,9 +32,15 @@ jobs:
       - name: Make Nuget Packages
         run: dotnet pack -c Release
 
+      - name: NuGet login (OIDC to temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: Nefarius
+
       - name: Publish To Nuget
         run: |
           dotnet nuget push bin/*.nupkg --skip-duplicate -k "$NUGET_AUTH_TOKEN" -s https://api.nuget.org/v3/index.json
           dotnet nuget push bin/*.snupkg --skip-duplicate -k "$NUGET_AUTH_TOKEN" -s https://api.nuget.org/v3/index.json
         env:
-          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
+          NUGET_AUTH_TOKEN: ${{ steps.login.outputs.NUGET_API_KEY }}

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -33,14 +33,14 @@ jobs:
         run: dotnet pack -c Release
 
       - name: NuGet login (OIDC to temp API key)
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
         id: login
         with:
           user: Nefarius
 
       - name: Publish To Nuget
         run: |
-          dotnet nuget push bin/*.nupkg --skip-duplicate -k "$NUGET_AUTH_TOKEN" -s https://api.nuget.org/v3/index.json
-          dotnet nuget push bin/*.snupkg --skip-duplicate -k "$NUGET_AUTH_TOKEN" -s https://api.nuget.org/v3/index.json
+          dotnet nuget push bin/*.nupkg --skip-duplicate -s https://api.nuget.org/v3/index.json
+          dotnet nuget push bin/*.snupkg --skip-duplicate -s https://api.nuget.org/v3/index.json
         env:
-          NUGET_AUTH_TOKEN: ${{ steps.login.outputs.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated NuGet package publishing to use short-lived, securely generated authentication credentials.
  * Added OIDC-based authentication and limited repository permissions for safer automated releases.
  * Removed reliance on a stored publishing secret during package deployment.
  * Package publishing behavior remains unchanged for consumers, while release automation is more secure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->